### PR TITLE
Fix crash when direction=left or right

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -45,14 +45,14 @@ pub fn draw(w: &mut Stdout, rain: &Rain, spacing: u16, direction: &Direction) ->
         let slice = chr[start..end].iter();
 
         let cstart = if col > len {
-            clr.len() - slice.len()
+            clr.len().saturating_sub(slice.len())
         } else {
             0
         };
 
-        let color = &clr[cstart..clr.len()];
+        let color = &clr[cstart..];
 
-        for (y, ch) in slice.rev().enumerate() {
+        for (y, (ch, _c)) in slice.rev().zip(color.iter().copied()).enumerate() {
             queue!(
                 w,
                 move_to(
@@ -60,7 +60,7 @@ pub fn draw(w: &mut Stdout, rain: &Rain, spacing: u16, direction: &Direction) ->
                     (*col.min(&height) - y) as u16,
                     offset
                 ),
-                style::SetForegroundColor(color[y]),
+                style::SetForegroundColor(_c),
                 style::Print(ch),
             )?;
         }


### PR DESCRIPTION
When there are lots of rows on the screen (like 130), rusty-rain will crash because it will try to read `color` out-of-bounds or get an invalid subslice from `clr`.

It looks like an off-by-one error - "index is N, but len is N".

This is the workaround I'm using