### PR TITLE
remove itertools dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["command-line-utilities"]
 clap = { version = "4.5.43", features = ["cargo", "derive"] }
 crossterm = "0.29.0"
 rand = "0.9.2"
-itertools = "0.14.0"
 
 [profile.release]
 debug = true

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,12 +1,13 @@
 use crate::cli::Cli;
 use crate::{gen, style, Rain, Rng};
-use itertools::izip;
 use std::time::{Duration, Instant};
 
 pub fn update(rain: &mut Rain) {
     rain.queue.clear();
     let now = Instant::now();
-    for (idx, ((time, delay), location)) in izip!(&mut rain.time, &mut rain.locations).enumerate() {
+    for (idx, ((time, delay), location)) in
+        rain.time.iter_mut().zip(&mut rain.locations).enumerate()
+    {
         if *time <= now {
             *time += *delay;
             *location += 1;


### PR DESCRIPTION
Its kinda crazy to have dependencies on `itertools` for something that can be done without it pretty much the same.