### PR TITLE
update readme for winget install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,15 @@
 
 ## 🚀 Quick Install
 
-| Method                                   | Command                                                                                     |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------- |
-| Cargo (stable)                           | `cargo install rusty-rain`                                                                  |
-| Cargo (latest)                           | `cargo install --git https://github.com/cowboy8625/rusty-rain.git`                          |
-| [eget](https://github.com/zyedidia/eget) | `eget cowboy8625/rusty-rain`                                                                |
-| Docker (build)                           | `docker build -t rusty-rain . && docker run --rm -it rusty-rain alpha-num -s`               |
-| Docker (pull)                            | `docker run --rm -it ghcr.io/cowboy8625/rusty-rain:latest -c alpha-num -s`                  |
-| Debian Package                           | curl -sSL https://raw.githubusercontent.com/cowboy8625/rusty-rain/master/install.sh \| bash |
+| Method                                                                      | Command                                                                                     |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Cargo (stable)                                                              | `cargo install rusty-rain`                                                                  |
+| Cargo (latest)                                                              | `cargo install --git https://github.com/cowboy8625/rusty-rain.git`                          |
+| [eget](https://github.com/zyedidia/eget)                                    | `eget cowboy8625/rusty-rain`                                                                |
+| Docker (build)                                                              | `docker build -t rusty-rain . && docker run --rm -it rusty-rain alpha-num -s`               |
+| Docker (pull)                                                               | `docker run --rm -it ghcr.io/cowboy8625/rusty-rain:latest -c alpha-num -s`                  |
+| Debian Package                                                              | curl -sSL https://raw.githubusercontent.com/cowboy8625/rusty-rain/master/install.sh \| bash |
+| [WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget/) | winget install rusty-rain                                                                   |
 
 ---
 


### PR DESCRIPTION
Update Readme to show new install instruction using [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/).

Fixes #41 