### PR TITLE
Added feature to set bg_color using -B flag.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -293,6 +293,15 @@ OPTIONS:
     r,g,b
 ";
 
+const HELP_BG_COLORS: &str = "Set background color of Rain with color string name or tuple
+OPTIONS:
+    white,
+    red,
+    blue,
+    green,
+    r,g,b
+";
+
 const HELP_CHARS: &str = "Set what kind of characters are printed as rain.
 OPTIONS:
     all            - This shows most of the Character Groups all at once.
@@ -346,6 +355,8 @@ pub struct Cli {
     pub group: Grouping,
     #[arg(short = 'C', long, help = HELP_COLORS, default_value_t = String::from("green"))]
     pub color: String,
+    #[arg(short = 'B', long, help = HELP_BG_COLORS)]
+    pub bg_color: Option<String>,
     #[arg(short = 'H', long, help = HELP_HEAD, default_value_t = String::from("white"))]
     pub head: String,
     #[arg(short, long, help = HELP_DIRECTION, default_value = "south")]
@@ -364,6 +375,11 @@ pub struct Cli {
 impl Cli {
     pub fn rain_color(&self) -> (u8, u8, u8) {
         into_color(&self.color)
+    }
+
+    pub fn rain_bg_color(&self) -> Option<(u8, u8, u8)> {
+        // Convert color from Option<String> to Option<u8,u8,u8>.
+        self.bg_color.as_ref().map(|col| into_color(col.as_str()))
     }
     pub fn head_color(&self) -> (u8, u8, u8) {
         into_color(&self.head)

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod test;
 use clap::Parser;
 use crossterm::{
     cursor, event, execute, queue,
-    style::{Color, Print, SetForegroundColor},
+    style::{Color, Print, SetBackgroundColor, SetForegroundColor},
     terminal,
 };
 use ezemoji::CharGroup;
@@ -477,7 +477,7 @@ impl App {
     fn run(&mut self, settings: cli::Cli) -> std::io::Result<()> {
         let (w, h) = terminal::size()?;
         let mut rain = Rain::<1024>::new(w as usize, h as usize, &settings);
-        self.setup_terminal()?;
+        self.setup_terminal(&settings)?;
 
         let mut is_running = true;
         while is_running {
@@ -506,9 +506,18 @@ impl App {
     }
 
     #[inline(always)]
-    fn setup_terminal(&mut self) -> std::io::Result<()> {
+    fn setup_terminal(&mut self, settings: &cli::Cli) -> std::io::Result<()> {
         terminal::enable_raw_mode()?;
         execute!(self.stdout, terminal::EnterAlternateScreen, cursor::Hide)?;
+
+        // SetBackgroundColor() should only be called if settings.bg_color is Some().
+        // settings.bg_color will only be Some() if user has passed in a -B flag.
+        if settings.bg_color.is_some()
+            && let Some(col) = settings.rain_bg_color()
+        {
+            execute!(self.stdout, SetBackgroundColor(col.into()))?
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
Hello, I have added a feature to allow the user to specify a background color using the -B flag, similar to how they would specify a color with the -C flag. There is no default value for -B so if user doesn't specify it, it never gets set.

<img width="1307" height="607" alt="image" src="https://github.com/user-attachments/assets/aa0a1718-c822-485d-be20-7ed066d44fed" />
<img width="1307" height="607" alt="image" src="https://github.com/user-attachments/assets/08672c57-ab5a-4e4b-9973-65d52666fd78" />

Implementation:
- Added a bg_color field of type Option<String> to the Cli struct. 
- Added rain_bg_color() to get background color in Option<u8,u8,u8> form. 
- bg_color being Option allows us to ignore bg_color if user hasn't specified the -B flag. If bg_color is passed in through CLI arguments, then SetBackgroundColor() sets the background color to that color. 
- In setup_terminal() I wasn't sure if I could put the logic into the same execute!() call so I made a separate one to call SetBackgroundColor().

Notes:
One small caveat is that background color won't fully take effect until the program has drawn characters on all cells visible on the screen, so for the first few seconds of the runtime you'll see something like this:
<img width="1307" height="607" alt="image" src="https://github.com/user-attachments/assets/66ed416d-d6d7-4718-a1a9-3cc8638fd79a" />

But that only lasts for a few seconds, and eventually the background color fills the entire screen. 