### PR TITLE
feat: Add shade gradient color configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,29 @@ Options:
 
           [default: green]
 
+  -B, --bg-color <BG_COLOR>
+          Set background color of Rain with color string name or tuple
+          OPTIONS:
+              white,
+              red,
+              blue,
+              green,
+              r,g,b
+
+
+  -G, --shade-gradient <SHADE_GRADIENT>
+          Set shade gradient color of Rain.
+          OPTIONS:
+              white,
+              red,
+              blue,
+              green,
+              r,g,b,
+              #RRGGBB
+
+
+          [default: #000000]
+
   -H, --head <HEAD>
           Set the color of the first char in Rain.
           OPTIONS:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -302,14 +302,14 @@ OPTIONS:
     r,g,b
 ";
 
-const HELP_SHADE_GRADIENT_COLORS: &str =
-    "Set shade gradient color of Rain with color string name or tuple
+const HELP_SHADE_GRADIENT_COLORS: &str = "Set shade gradient color of Rain.
 OPTIONS:
     white,
     red,
     blue,
     green,
-    r,g,b
+    r,g,b,
+    #RRGGBB
 ";
 
 const HELP_CHARS: &str = "Set what kind of characters are printed as rain.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,6 +47,7 @@ impl Group {
 pub struct Config {
     pub shade: Option<bool>,
     pub color: Option<String>,
+    pub shade_gradient: Option<String>,
     pub head: Option<String>,
     pub direction: Option<Direction>,
     pub speed: Option<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -302,6 +302,16 @@ OPTIONS:
     r,g,b
 ";
 
+const HELP_SHADE_GRADIENT_COLORS: &str =
+    "Set shade gradient color of Rain with color string name or tuple
+OPTIONS:
+    white,
+    red,
+    blue,
+    green,
+    r,g,b
+";
+
 const HELP_CHARS: &str = "Set what kind of characters are printed as rain.
 OPTIONS:
     all            - This shows most of the Character Groups all at once.
@@ -357,6 +367,8 @@ pub struct Cli {
     pub color: String,
     #[arg(short = 'B', long, help = HELP_BG_COLORS)]
     pub bg_color: Option<String>,
+    #[arg(short = 'G', long, help = HELP_SHADE_GRADIENT_COLORS, default_value_t = String::from("#000000"))]
+    pub shade_gradient: String,
     #[arg(short = 'H', long, help = HELP_HEAD, default_value_t = String::from("white"))]
     pub head: String,
     #[arg(short, long, help = HELP_DIRECTION, default_value = "south")]
@@ -382,6 +394,10 @@ impl Cli {
     }
     pub fn head_color(&self) -> (u8, u8, u8) {
         into_color(&self.head)
+    }
+
+    pub fn shade_gradient_color(&self) -> (u8, u8, u8) {
+        into_color(&self.shade_gradient)
     }
 
     pub fn speed(&self) -> (u64, u64) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -552,31 +552,35 @@ impl Drop for App {
     }
 }
 
-/// Generates a vector of Colors that fade to black over the length of the column.
-fn gen_shade_color(bc: Color, shade_color: Color, length: u8) -> Vec<Color> {
-    let mut colors = Vec::with_capacity(length as usize);
-    let Color::Rgb { r, g, b } = bc else {
-        return colors;
-    };
-    let Color::Rgb {
-        r: shade_r,
-        g: shade_g,
-        b: shade_b,
-    } = shade_color
+/// Generates a vector of Colors that fade to `black` over the length of the column.
+fn gen_shade_color(base: Color, shade: Color, length: u8) -> Vec<Color> {
+    let (
+        Color::Rgb {
+            r: br,
+            g: bg,
+            b: bb,
+        },
+        Color::Rgb {
+            r: sr,
+            g: sg,
+            b: sb,
+        },
+    ) = (base, shade)
     else {
-        return colors;
+        return Vec::new();
     };
 
+    let mut colors = Vec::with_capacity(length as usize);
+
     for i in 0..length {
-        let mix = (
-            ((r as f32 * (i as f32 / length as f32))
-                + (shade_r as f32 * ((length - i) as f32 / length as f32))) as u8,
-            ((g as f32 * (i as f32 / length as f32))
-                + (shade_g as f32 * ((length - i) as f32 / length as f32))) as u8,
-            ((b as f32 * (i as f32 / length as f32))
-                + (shade_b as f32 * ((length - i) as f32 / length as f32))) as u8,
-        );
-        colors.push(mix.into());
+        let t = i as f32 / length as f32;
+        let s = 1.0 - t;
+
+        let r = ((br as f32 * t) + (sr as f32 * s)) as u8;
+        let g = ((bg as f32 * t) + (sg as f32 * s)) as u8;
+        let b = ((bb as f32 * t) + (sb as f32 * s)) as u8;
+
+        colors.push(Color::Rgb { r, g, b });
     }
     colors.reverse();
     colors

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,6 +155,8 @@ struct Rain<const LENGTH: usize> {
     body_colors: Vec<(Color, Option<Vec<Color>>)>,
     /// Shading of the rain
     shading: bool,
+    /// Color to fade into when shading is enabled
+    shade_gradient: Color,
     /// Color of the rain head
     head_colors: Vec<Color>,
     /// Direction of the rain
@@ -227,12 +229,13 @@ impl<const LENGTH: usize> Rain<LENGTH> {
             })
             .collect();
 
+        let shade_color: Color = settings.shade_gradient_color().into();
         let body_colors = if settings.shade {
             let base_color: Color = settings.rain_color().into();
             (0..width)
                 .map(|i| {
                     let window = windows[i].saturating_sub(1);
-                    let colors = gen_shade_color(base_color, window as u8);
+                    let colors = gen_shade_color(base_color, shade_color, window as u8);
                     (base_color, Some(colors))
                 })
                 .collect::<Vec<_>>()
@@ -242,6 +245,7 @@ impl<const LENGTH: usize> Rain<LENGTH> {
 
         Self {
             shading: settings.shade,
+            shade_gradient: shade_color,
             body_colors,
             chars,
             directions: vec![settings.direction; width],
@@ -305,7 +309,7 @@ impl<const LENGTH: usize> Rain<LENGTH> {
         }
         let base_color: Color = self.body_colors[i].0;
         let window = self.windows[i].saturating_sub(1);
-        let colors = gen_shade_color(base_color, window as u8);
+        let colors = gen_shade_color(base_color, self.shade_gradient, window as u8);
         self.body_colors[i] = (base_color, Some(colors));
     }
 
@@ -549,16 +553,33 @@ impl Drop for App {
 }
 
 /// Generates a vector of Colors that fade to black over the length of the column.
-fn gen_shade_color(bc: Color, length: u8) -> Vec<Color> {
+fn gen_shade_color(bc: Color, shade_color: Color, length: u8) -> Vec<Color> {
     let mut colors = Vec::with_capacity(length as usize);
     let Color::Rgb { r, g, b } = bc else {
+        return colors;
+    };
+    let Color::Rgb {
+        r: shade_r,
+        g: shade_g,
+        b: shade_b,
+    } = shade_color
+    else {
         return colors;
     };
     let nr = r / length;
     let ng = g / length;
     let nb = b / length;
+    let fade_r = shade_r / length;
+    let fade_g = shade_g / length;
+    let fade_b = shade_b / length;
+
     for i in 0..length {
-        colors.push((nr * i, ng * i, nb * i).into());
+        let mix = (
+            ((nr as f32 * i as f32) + (fade_r as f32 * (length as f32 - i as f32))) as u8,
+            ((ng as f32 * i as f32) + (fade_g as f32 * (length as f32 - i as f32))) as u8,
+            ((nb as f32 * i as f32) + (fade_b as f32 * (length as f32 - i as f32))) as u8,
+        );
+        colors.push(mix.into());
     }
     colors.reverse();
     colors

--- a/src/main.rs
+++ b/src/main.rs
@@ -596,6 +596,9 @@ fn update_settings_with_config(settings: &mut cli::Cli) {
     if let Some(color) = config.color {
         settings.color = color;
     }
+    if let Some(shade_gradient) = config.shade_gradient {
+        settings.shade_gradient = shade_gradient;
+    }
     if let Some(head) = config.head {
         settings.head = head;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -566,18 +566,15 @@ fn gen_shade_color(bc: Color, shade_color: Color, length: u8) -> Vec<Color> {
     else {
         return colors;
     };
-    let nr = r / length;
-    let ng = g / length;
-    let nb = b / length;
-    let fade_r = shade_r / length;
-    let fade_g = shade_g / length;
-    let fade_b = shade_b / length;
 
     for i in 0..length {
         let mix = (
-            ((nr as f32 * i as f32) + (fade_r as f32 * (length as f32 - i as f32))) as u8,
-            ((ng as f32 * i as f32) + (fade_g as f32 * (length as f32 - i as f32))) as u8,
-            ((nb as f32 * i as f32) + (fade_b as f32 * (length as f32 - i as f32))) as u8,
+            ((r as f32 * (i as f32 / length as f32))
+                + (shade_r as f32 * ((length - i) as f32 / length as f32))) as u8,
+            ((g as f32 * (i as f32 / length as f32))
+                + (shade_g as f32 * ((length - i) as f32 / length as f32))) as u8,
+            ((b as f32 * (i as f32 / length as f32))
+                + (shade_b as f32 * ((length - i) as f32 / length as f32))) as u8,
         );
         colors.push(mix.into());
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -134,10 +134,11 @@ snapshot!(
 fn test_gen_shade_color() {
     use super::{Color, gen_shade_color};
     use pretty_assertions::assert_eq;
+    const TRUE_BLACK: Color = Color::Rgb { r: 0, g: 0, b: 0 };
     let bc = Color::Rgb { r: 0, g: 255, b: 0 };
     let length = 10;
 
-    let colors = gen_shade_color(bc, length);
+    let colors = gen_shade_color(bc, TRUE_BLACK, length);
 
     assert_eq!(colors.len(), length as usize);
     assert_eq!(colors.first(), Some(&Color::Rgb { r: 0, g: 225, b: 0 }));


### PR DESCRIPTION
Naming this feature is a bit difficult, but the idea is that instead of the `--shade`/`-s` option always causing a fade to black, the user can specify a color to "fade" to using `--shade-gradient`/`-G`.

This can be used to correct the shade effect for terminals with a different background color, to correct the shade effect when using the `--bg-color`/`-B` option, or to achieve a simple linear gradient between two colors.

The default is pure black (`#000000`). This is for compatibility, but note that the colors with the new implementation may be very slightly different. They were identical in the original commit, but that was lost when fixing an issue with colors close to black.

<details><summary>Linear Gradient</summary>
<p>

Alacritty 0.16.1, with the command `rusty-rain -s -g classic -C red --shade-gradient "#0000FF"`. The default background color of Alacritty is `#181818`, according to [the section on configuration on the Alacritty website].

<img width="938" height="699" alt="example_a" src="https://github.com/user-attachments/assets/5ebedffa-d929-4b12-aedf-c7ee3f29dfcd" />

</p>

</details> 

<details><summary>Correcting <code>--bg-color</code>/<code>-B</code> </summary>
<p>

Alacritty 0.16.1, with the command `rusty-rain -s -C green -B blue --shade-gradient blue`.

<img width="938" height="694" alt="example_b" src="https://github.com/user-attachments/assets/e9b5e60d-cbf9-4a53-9fff-d9fae0747d01" />

</p>
</details> 

<details><summary>Correcting Terminal Backgrounds</summary>
<p>

Alacritty 0.16.1, with the command `rusty-rain -s -g classic -C red --shade-gradient "#181818"`. The default background color of Alacritty is `#181818`, according to [the section on configuration on the Alacritty website].

<img width="938" height="694" alt="example_c" src="https://github.com/user-attachments/assets/19d98bac-3c8e-40ea-9254-b1a3687b4dcf" />

</p>







[the section on configuration on the Alacritty website]: https://alacritty.org/config-alacritty.html#s35